### PR TITLE
When Aries Blueprint is present, delegates to him blueprint instantiation

### DIFF
--- a/extender/src/main/java/org/eclipse/gemini/blueprint/extender/internal/blueprint/activator/support/BlueprintContainerCreator.java
+++ b/extender/src/main/java/org/eclipse/gemini/blueprint/extender/internal/blueprint/activator/support/BlueprintContainerCreator.java
@@ -25,6 +25,9 @@ import org.eclipse.gemini.blueprint.extender.support.ApplicationContextConfigura
 import org.eclipse.gemini.blueprint.util.OsgiStringUtils;
 import org.springframework.util.ObjectUtils;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Blueprint specific context creator. Picks up the Blueprint locations instead of Spring DM's.
  * 
@@ -48,6 +51,16 @@ public class BlueprintContainerCreator implements OsgiApplicationContextCreator 
 		if (!config.isSpringPoweredBundle()) {
 			if (log.isDebugEnabled())
 				log.debug("No blueprint configuration found in bundle " + bundleName + "; ignoring it...");
+			return null;
+		}
+
+		// If Aries Blueprint is present, delegates to him the blueprint instantiation
+		List<Bundle> allBundles = Arrays.asList(bundleContext.getBundles());
+		boolean hasAries = allBundles.stream()
+						.anyMatch(b -> b.getSymbolicName().equals("org.apache.aries.blueprint.core"));
+		if (hasAries) {
+			log.info("[Gemini Extender] Aries Blueprint is enabled at the running container, skipping blueprint " +
+							"instantiation for bundle " + bundleName + "...");
 			return null;
 		}
 


### PR DESCRIPTION
With the old spring-dm it was possible to use spring-powered bundles and aries-blueprint bundles within the same container, with gemini the same can not be achieved. That's because there are several thirdparty bundles which are strongly tied with aries-blueprint implementation and gemini can not parse those bundles correctly. 

This patch checks if aries is present at the running container, if it is, gemini ignores blueprint-bundles allowing aries to instantiate them. 
