### PR TITLE
Switch to `https` repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1026,7 +1026,7 @@
         <pluginRepository>
             <id>maven-repo</id>
             <name>maven repo</name>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -1034,13 +1034,13 @@
         <repository>
             <id>maven-repo</id>
             <name>maven repo</name>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
 
         <repository>
             <id>knopflerfish-repo</id>
             <name>Official Knopflerfish Repository</name>
-            <url>http://www.knopflerfish.org/maven2/</url>
+            <url>https://www.knopflerfish.org/maven2/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This avoids `Blocked mirror` build failures